### PR TITLE
Fix OCR monto parsing

### DIFF
--- a/app/regex.py
+++ b/app/regex.py
@@ -1,6 +1,13 @@
 import re
 
 def parse_fields(text):
+    """Extrae fecha, monto y cuenta de un texto OCR.
+
+    Ejemplos de conversión de monto:
+    - "Gs. 195C"   -> 195000
+    - "Gs 195.000" -> 195000
+    - "Gs 10O50"   -> 10050
+    """
     print("🔍 Texto recibido para parsear:\n", text)
 
     # Buscar fecha
@@ -19,11 +26,16 @@ def parse_fields(text):
     if monto_match:
         bruto = monto_match.group(1)
         print("🛠️ Monto antes de limpiar:", bruto)
-        bruto = bruto.replace('C', '.').replace('O', '0').replace('o', '0')
-        bruto = re.sub(r'[^\d.]', '', bruto)
-        print("🧹 Monto limpio:", bruto)
+        # Mapear posibles errores de OCR a dígitos y miles
+        limpio = bruto.replace('O', '0').replace('o', '0')
+        # 'C' suele aparecer en lugar de '.000'
+        limpio = limpio.replace('C', '000')
+        # Eliminar separadores de miles
+        limpio = limpio.replace('.', '').replace(',', '')
+        limpio = re.sub(r'\D', '', limpio)
+        print("🧹 Monto limpio:", limpio)
         try:
-            monto_val = int(float(bruto))
+            monto_val = int(limpio)
             print("✅ Monto final:", monto_val)
         except Exception as e:
             print("❌ Error convirtiendo monto a número:", e)


### PR DESCRIPTION
## Summary
- clean `parse_fields` to handle OCR mistakes like `C`, `O`, `o`
- strip thousand separators, convert directly to int
- add inline docstring with examples

## Testing
- `python3 - <<'PY'
from app.regex import parse_fields
samples = ["Gs. 195C", "Gs. 195.000", "Gs 10O50", "Gs 195,000", "G5 1o0C"]
for s in samples:
    print(parse_fields(s)["monto"])
PY`

------
https://chatgpt.com/codex/tasks/task_e_687daad94c288330b87cd3f60bbbc644