### PR TITLE
Implement parsers for Ueno Bank receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Este proyecto implementa un bot de Telegram que recibe fotos de comprobantes de 
   - `regex.py`: define las expresiones regulares para identificar fecha, monto y número de comprobante.
   - `bd_sqlalchemy.py`: configuración de SQLAlchemy y función `save_record` que persiste los pagos.
   - `requirements.txt`: dependencias de la aplicación.
+  - `parser/`: paquete con parsers especializados por tipo de comprobante (pago, transferencia y servicio) de Ueno Bank.
 
 ## Ejecución rápida
 

--- a/app/parser/__init__.py
+++ b/app/parser/__init__.py
@@ -1,0 +1,13 @@
+"""Parsers de comprobantes del banco Ueno."""
+
+from .dispatcher import get_parser
+from .ueno_pago import parse as parse_pago
+from .ueno_transferencia import parse as parse_transferencia
+from .ueno_servicio import parse as parse_servicio
+
+__all__ = [
+    "get_parser",
+    "parse_pago",
+    "parse_transferencia",
+    "parse_servicio",
+]

--- a/app/parser/base_parser.py
+++ b/app/parser/base_parser.py
@@ -1,0 +1,51 @@
+import re
+from datetime import datetime
+from typing import Optional, Tuple
+
+
+def normalize_amount(text: str) -> Optional[int]:
+    """Extrae y normaliza montos en guaraníes de un bloque de texto."""
+    monto_match = re.search(r"\b(?:G[s5]|6S|C[s5]|CS)[^\d]*([\dOCoC.,]+)", text, re.IGNORECASE)
+    if not monto_match:
+        return None
+    bruto = monto_match.group(1)
+    limpio = bruto.replace('O', '0').replace('o', '0')
+    limpio = limpio.replace('C', '000').replace('c', '000')
+    limpio = limpio.replace('S', '5').replace('s', '5')
+    limpio = limpio.replace('.', '').replace(',', '')
+    limpio = re.sub(r"\D", "", limpio)
+    if not limpio:
+        return None
+    try:
+        return int(limpio)
+    except Exception:
+        return None
+
+
+def parse_date_time(text: str) -> Tuple[Optional[str], Optional[str]]:
+    """Devuelve fecha YYYY-MM-DD y hora HH:MM si están presentes."""
+    dt_match = re.search(
+        r"(\d{2}/\d{2}/\d{4})\s*(?:a\s*las)?\s*(\d{1,2}[.:]\d{2})",
+        text,
+        re.IGNORECASE | re.S,
+    )
+    fecha = hora = None
+    if dt_match:
+        fecha_raw = dt_match.group(1)
+        hora_raw = dt_match.group(2).replace(".", ":").replace(" ", "")
+        try:
+            fecha = datetime.strptime(fecha_raw, "%d/%m/%Y").strftime("%Y-%m-%d")
+        except Exception:
+            fecha = None
+        parts = hora_raw.split(":")
+        if len(parts) == 2:
+            try:
+                hora = f"{int(parts[0]):02d}:{int(parts[1]):02d}"
+            except Exception:
+                hora = None
+    return fecha, hora
+
+
+def parse_nro_comprobante(text: str) -> Optional[str]:
+    match = re.search(r"comprobante\s*:?\s*(\d+)", text, re.IGNORECASE)
+    return match.group(1) if match else None

--- a/app/parser/dispatcher.py
+++ b/app/parser/dispatcher.py
@@ -1,0 +1,22 @@
+from typing import Callable
+
+from .ueno_pago import parse as parse_pago
+from .ueno_transferencia import parse as parse_transferencia
+from .ueno_servicio import parse as parse_servicio
+
+
+KEYWORDS = [
+    ("comprobante de transferencia", parse_transferencia),
+    ("pago de servicio", parse_servicio),
+    ("comprobante de pago de servicios", parse_servicio),
+    ("comprobante de pago", parse_pago),
+]
+
+
+def get_parser(data: str) -> Callable[[str], dict]:
+    """Devuelve la función parse adecuada según palabras clave."""
+    texto = data.lower()
+    for palabra, parser in KEYWORDS:
+        if palabra in texto:
+            return parser
+    return parse_pago

--- a/app/parser/ueno_pago.py
+++ b/app/parser/ueno_pago.py
@@ -1,0 +1,23 @@
+import re
+from typing import Dict
+from .base_parser import normalize_amount, parse_date_time, parse_nro_comprobante
+
+
+def parse(data: str) -> Dict[str, object]:
+    fecha, hora = parse_date_time(data)
+    monto = normalize_amount(data)
+    nro = parse_nro_comprobante(data)
+
+    comercio = None
+    m = re.search(r"Comercio\s*:?\s*(.+)", data, re.IGNORECASE)
+    if m:
+        comercio = m.group(1).strip()
+
+    return {
+        "tipo": "pago",
+        "fecha": fecha,
+        "hora": hora,
+        "monto": monto,
+        "nro_comprobante": nro,
+        "comercio": comercio,
+    }

--- a/app/parser/ueno_servicio.py
+++ b/app/parser/ueno_servicio.py
@@ -1,0 +1,35 @@
+import re
+from typing import Dict
+from .base_parser import normalize_amount, parse_date_time, parse_nro_comprobante
+
+
+def parse(data: str) -> Dict[str, object]:
+    fecha, hora = parse_date_time(data)
+    monto = normalize_amount(data)
+    nro = parse_nro_comprobante(data)
+
+    cuenta = None
+    m = re.search(r"Cuenta\s+origen\s*:?\s*(\S+)", data, re.IGNORECASE)
+    if m:
+        cuenta = m.group(1).strip()
+
+    entidad = None
+    m = re.search(r"Entidad\s*:?\s*(.+)", data, re.IGNORECASE)
+    if m:
+        entidad = m.group(1).strip()
+
+    operacion = None
+    m = re.search(r"Operaci\w+n\s*:?\s*(.+)", data, re.IGNORECASE)
+    if m:
+        operacion = m.group(1).strip()
+
+    return {
+        "tipo": "servicio",
+        "fecha": fecha,
+        "hora": hora,
+        "monto": monto,
+        "nro_comprobante": nro,
+        "cuenta_origen": cuenta,
+        "entidad": entidad,
+        "beneficiario": operacion,
+    }

--- a/app/parser/ueno_transferencia.py
+++ b/app/parser/ueno_transferencia.py
@@ -1,0 +1,35 @@
+import re
+from typing import Dict
+from .base_parser import normalize_amount, parse_date_time, parse_nro_comprobante
+
+
+def parse(data: str) -> Dict[str, object]:
+    fecha, hora = parse_date_time(data)
+    monto = normalize_amount(data)
+    nro = parse_nro_comprobante(data)
+
+    remitente = None
+    m = re.search(r"Remitente\s*:?\s*(.+)", data, re.IGNORECASE)
+    if m:
+        remitente = m.group(1).strip()
+
+    destinatario = None
+    m = re.search(r"Destinatario\s*:?\s*(.+)", data, re.IGNORECASE)
+    if m:
+        destinatario = m.group(1).strip()
+
+    entidad = None
+    m = re.search(r"Entidad\s*destino\s*:?\s*(.+)", data, re.IGNORECASE)
+    if m:
+        entidad = m.group(1).strip()
+
+    return {
+        "tipo": "transferencia",
+        "fecha": fecha,
+        "hora": hora,
+        "monto": monto,
+        "nro_comprobante": nro,
+        "cuenta_origen": remitente,
+        "beneficiario": destinatario,
+        "entidad": entidad,
+    }


### PR DESCRIPTION
## Summary
- document new `parser/` package in the README
- implement `parser` package with base helper functions
- add individual parsers for Ueno Bank payment, transfer and service receipts
- include a dispatcher to pick the correct parser based on OCR text

## Testing
- `python -m py_compile app/parser/*.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e83c217fc8330bde9ef79ff973563