### PR TITLE
Mezcla datos básicos y de parser

### DIFF
--- a/app/bot_handler.py
+++ b/app/bot_handler.py
@@ -14,8 +14,12 @@ def process_image(path, update, ctx):
     print(text)
     parser_fn = get_parser(text)
     fields = parser_fn(text)
-    if not fields.get('fecha') or not fields.get('monto'):
-        fields = parse_fields(text)
+
+    # Extraer campos básicos con expresiones regulares si faltan
+    fallback = parse_fields(text)
+    for key, val in fallback.items():
+        if not fields.get(key) and val:
+            fields[key] = val
 
     ctx.bot.send_message(update.effective_chat.id, f"OCR detectado:\n{text[:400]}...")
 


### PR DESCRIPTION
## Summary
- use regex parse results as fallback instead of replacing parser data

## Testing
- `python -m py_compile app/*.py app/parser/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6886d0d5828c8330a20b1607aea2d9e3